### PR TITLE
Fix daily aggregation in air quality cleaning

### DIFF
--- a/feature_engineering.py
+++ b/feature_engineering.py
@@ -214,12 +214,13 @@ def air_clean_transform(dataframe):
     # Rename dt to date
     dataframe.rename(columns={"dt": "date"}, inplace=True)
 
-    # Convert unix timestamp to datetime
-    dataframe["date"] = pd.to_datetime(dataframe["date"], unit="s")
+    # Convert unix timestamp to datetime and drop the time component
+    dataframe["date"] = pd.to_datetime(dataframe["date"], unit="s").dt.floor("D")
 
-    # Air quality raw dataframe is recorded per hour.
-    # Aggregated dataframe into daily averages
-    dataframe = dataframe.groupby("date").mean().reset_index()
+    # Air quality raw dataframe is recorded per hour. Aggregate into daily means
+    dataframe = (
+        dataframe.groupby("date").mean(numeric_only=True).reset_index()
+    )
 
     # Drop irrelevant feature
     dataframe.drop("aqi", axis=1, inplace=True)


### PR DESCRIPTION
## Summary
- aggregate hourly air quality values by day correctly

## Testing
- `python -m py_compile feature_engineering.py app.py`
- `python - <<'EOF'
from feature_engineering import air_clean_transform
import pandas as pd
unix_times = pd.date_range('2024-01-01', periods=48, freq='H').view('int64')//10**9
df = pd.DataFrame({'dt': unix_times, 'pm2_5': range(48), 'pm10': range(100,148), 'aqi': range(200,248)})
print(air_clean_transform(df))
EOF

------
https://chatgpt.com/codex/tasks/task_e_68430c8afd30832cab8f8901ae452110